### PR TITLE
Feat/#1

### DIFF
--- a/fastapi/intent-recognition-api/app/models/intent.py
+++ b/fastapi/intent-recognition-api/app/models/intent.py
@@ -15,3 +15,9 @@ class SearchRequest(BaseModel):
 
 class SearchResponse(BaseModel):
     vector: list[float]
+
+class SearchQueryRequest(BaseModel):
+    text: str
+
+class SearchQueryResponse(BaseModel):
+    query: str

--- a/fastapi/intent-recognition-api/app/routers/query.py
+++ b/fastapi/intent-recognition-api/app/routers/query.py
@@ -1,9 +1,20 @@
 from fastapi import APIRouter, HTTPException
 from app.services.query_vectorizer import vectorized_text
+from app.services.intent_classifier import intent_classifier
 
+# convert query to embedding vector router
 async def vectorized_text(text: str):
     try:
         vector = vectorized_text(text)
         return vector
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# get query router
+async def get_query(text : str):
+    try:
+        intent = intent_classifier.classify_intent(text)
+        query = intent_classifier.generate_query_by_intent(intent)
+        return query
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/fastapi/intent-recognition-api/app/routers/router.py
+++ b/fastapi/intent-recognition-api/app/routers/router.py
@@ -1,15 +1,22 @@
 from fastapi import APIRouter
-from app.models.intent import IntentRequest, IntentResponse, SearchRequest, SearchResponse
-from app.services.intent_classifier import intent_classifier
-from app.services.query_vectorizer import query_vectorizer
+from app.models.intent import IntentRequest, IntentResponse, SearchRequest, SearchResponse, SearchQueryRequest, SearchQueryResponse
+from app.services.intent_classifier import generate_query_by_intent, classify_intent
+from app.services.query_vectorizer import vectorized_text
 
 router = APIRouter()
 
 @router.post("/recognize-intent", response_model=IntentResponse)
 async def recognize_intent(request: IntentRequest):
-    return intent_classifier.classify_intent(request.text)
+    return classify_intent(request.text)
 
 
 @router.post("/vectorized-text", response_model=SearchResponse)
 async def vectorized_text(request: SearchRequest):
-    return query_vectorizer.vectorized_text(request.text)
+    return vectorized_text(request.text)
+
+@router.post("/query", response_model=SearchQueryResponse)
+async def get_query(request: SearchQueryRequest):
+    intent = classify_intent(request.text)
+    print("intent : ", intent['intent'])
+    query = generate_query_by_intent(intent['intent'])
+    return query

--- a/fastapi/intent-recognition-api/app/services/intent_classifier.py
+++ b/fastapi/intent-recognition-api/app/services/intent_classifier.py
@@ -1,6 +1,7 @@
 from transformers import pipeline
 from typing import Dict, List
 from app.services.model import model
+from app.services.query.query_factory import QueryFactory
 
 class IntentClassifier:
     def __init__(self):
@@ -27,8 +28,16 @@ class IntentClassifier:
                 "intent": "unknown",
                 "confidence": 0.0
             }
-
+    def generate_query_by_intent(self, intent: str) -> Dict[str, str]:
+        query_generator = QueryFactory.create_query(intent)
+        return query_generator.generate_query(intent)
+    
 intent_classifier = IntentClassifier()
 
 def classify_intent(input_data: str) -> Dict[str, List[str]]:
     return intent_classifier.classify_intent(input_data)
+
+def generate_query_by_intent(intent: str) -> Dict[str, str]:
+    query = intent_classifier.generate_query_by_intent(intent)
+    print('query:', query)
+    return {'query' : query}

--- a/fastapi/intent-recognition-api/app/services/query/address_name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_name_query.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+
+
+class AddressNameQuery:
+    def __init__(self):
+        pass
+    def generate_query(self, query_embedding : List[float]) -> str:
+        return '''{
+            "_source": ["title", "address", "location"],
+            "query": {
+            "script_score": {
+                "query": {
+                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                },
+                "script": {
+                "source": """
+                    double titleWeight = params.title_weight;
+                    double addressWeight = params.address_weight;
+                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + 
+                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
+                """,
+                "params": {
+                    "query_vector": query_embedding,
+                    "title_weight": 1.0,  # 기본 가중치 값
+                    "address_weight": 1.0  # 기본 가중치 값
+                }
+                }
+            }
+            }
+        }'''
+
+
+address_name_query = AddressNameQuery()
+
+def generate_query(intent: str) -> Dict[str, str]:
+    return address_name_query.generate_query(intent)

--- a/fastapi/intent-recognition-api/app/services/query/address_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_query.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+from app.services.query.query_interface import QueryInterface
+
+class AddressQuery(QueryInterface):
+    def __init__(self):
+        pass
+    def generate_query(self, query_embedding : List[float]) -> str:
+        return '''{
+            "_source": ["title", "address", "location"],
+            "query": {
+            "script_score": {
+                "query": {
+                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                },
+                "script": {
+                "source": """
+                    double titleWeight = params.title_weight;
+                    double addressWeight = params.address_weight;
+                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + 
+                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
+                """,
+                "params": {
+                    "query_vector": query_embedding,
+                    "title_weight": 0.0,  # 기본 가중치 값
+                    "address_weight": 1.0  # 기본 가중치 값
+                }
+                }
+            }
+            }
+        }'''
+
+
+address_query = AddressQuery()
+
+def generate_query(intent: str) -> Dict[str, str]:
+    return address_query.generate_query(intent)

--- a/fastapi/intent-recognition-api/app/services/query/name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/name_query.py
@@ -1,0 +1,31 @@
+from typing import Dict, List
+from app.services.query.query_interface import QueryInterface  # Absolute import
+
+
+class NameQuery(QueryInterface):
+    def __init__(self):
+        pass
+    def generate_query(self, query_embedding : List[float]) -> str:
+        return '''{
+            "_source": ["title", "address", "location"],
+            "query": {
+            "script_score": {
+                "query": {
+                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                },
+                "script": {
+                "source": """
+                    double titleWeight = params.title_weight;
+                    double addressWeight = params.address_weight;
+                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + 
+                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
+                """,
+                "params": {
+                    "query_vector": query_embedding,
+                    "title_weight": 1.0,  # 기본 가중치 값
+                    "address_weight": 0.0  # 기본 가중치 값
+                }
+                }
+            }
+            }
+        }'''

--- a/fastapi/intent-recognition-api/app/services/query/query_factory.py
+++ b/fastapi/intent-recognition-api/app/services/query/query_factory.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from app.services.query.query_interface import QueryInterface
+from app.services.query.name_query import NameQuery
+from app.services.query.address_query import AddressQuery
+from app.services.query.address_name_query import AddressNameQuery
+
+class QueryType(Enum):
+    NAME = "name"
+    ADDRESS = "address"
+    ADDRESS_NAME = "poi_name_address"
+
+class QueryFactory:
+    @staticmethod
+    def create_query(query_type: str) -> QueryInterface:
+        query_map = {
+            QueryType.NAME.value: NameQuery(),
+            QueryType.ADDRESS.value: AddressQuery(),
+            QueryType.ADDRESS_NAME.value: AddressNameQuery()
+        }
+        return query_map.get(query_type, NameQuery())
+    
+query_factory = QueryFactory()

--- a/fastapi/intent-recognition-api/app/services/query/query_interface.py
+++ b/fastapi/intent-recognition-api/app/services/query/query_interface.py
@@ -1,0 +1,8 @@
+from typing import Dict, List
+from abc import ABC, abstractmethod
+
+class QueryInterface(ABC):
+    @abstractmethod
+    def generate_query(self, query_embedding: List[float]) -> str:
+        pass
+    


### PR DESCRIPTION
# Add Query Generation Based on Intent Classification

## Related Issue
- #1 


## Changes Made
1. Added query template generation functionality
2. Implemented query factory pattern for different search types
3. Added new API endpoint for query generation

## New Endpoints
- POST `/query` : Generates Elasticsearch query based on text input
  - Classifies intent from input text
  - Returns appropriate query template

## Implementation Details
- Created QueryFactory for dynamic query generation
- Added query templates for:
  - POI name search
  - Address search
  - Combined search
- Integrated with existing intent classification

## Testing
```bash
# Test query generation endpoint
curl -X POST "http://localhost:8000/query" \
-H "Content-Type: application/json" \
-d '{"text":"강남역 스타벅스"}'