### PR TITLE
Feat/#4 Modify response field from 'script' to 'query' for ES query template

### DIFF
--- a/fastapi/intent-recognition-api/app/models/intent.py
+++ b/fastapi/intent-recognition-api/app/models/intent.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict
 from pydantic import BaseModel
 
 # 인텐트 검색 Request
@@ -20,4 +21,4 @@ class SearchQueryRequest(BaseModel):
     text: str
 
 class SearchQueryResponse(BaseModel):
-    query: str
+    script: str

--- a/fastapi/intent-recognition-api/app/routers/router.py
+++ b/fastapi/intent-recognition-api/app/routers/router.py
@@ -1,3 +1,4 @@
+import json
 from fastapi import APIRouter
 from app.models.intent import IntentRequest, IntentResponse, SearchRequest, SearchResponse, SearchQueryRequest, SearchQueryResponse
 from app.services.intent_classifier import generate_query_by_intent, classify_intent
@@ -17,6 +18,5 @@ async def vectorized_text(request: SearchRequest):
 @router.post("/query", response_model=SearchQueryResponse)
 async def get_query(request: SearchQueryRequest):
     intent = classify_intent(request.text)
-    print("intent : ", intent['intent'])
     query = generate_query_by_intent(intent['intent'])
-    return query
+    return SearchQueryResponse(script=json.dumps(query))

--- a/fastapi/intent-recognition-api/app/services/query/address_name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_name_query.py
@@ -10,7 +10,7 @@ class AddressNameQuery:
             "query": {
             "script_score": {
                 "query": {
-                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                "match_all": {}
                 },
                 "script": {
                 "source": """
@@ -21,8 +21,8 @@ class AddressNameQuery:
                 """,
                 "params": {
                     "query_vector": query_embedding,
-                    "title_weight": 1.0,  # 기본 가중치 값
-                    "address_weight": 1.0  # 기본 가중치 값
+                    "title_weight": 1.0, 
+                    "address_weight": 1.0
                 }
                 }
             }

--- a/fastapi/intent-recognition-api/app/services/query/address_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_query.py
@@ -10,7 +10,7 @@ class AddressQuery(QueryInterface):
             "query": {
             "script_score": {
                 "query": {
-                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                "match_all": {}
                 },
                 "script": {
                 "source": """
@@ -21,8 +21,8 @@ class AddressQuery(QueryInterface):
                 """,
                 "params": {
                     "query_vector": query_embedding,
-                    "title_weight": 0.0,  # 기본 가중치 값
-                    "address_weight": 1.0  # 기본 가중치 값
+                    "title_weight": 0.0,
+                    "address_weight": 1.0
                 }
                 }
             }

--- a/fastapi/intent-recognition-api/app/services/query/name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/name_query.py
@@ -11,7 +11,7 @@ class NameQuery(QueryInterface):
             "query": {
             "script_score": {
                 "query": {
-                "match_all": {}  # 모든 문서에서 스코어 기반 필터링
+                "match_all": {}
                 },
                 "script": {
                 "source": """
@@ -22,8 +22,8 @@ class NameQuery(QueryInterface):
                 """,
                 "params": {
                     "query_vector": query_embedding,
-                    "title_weight": 1.0,  # 기본 가중치 값
-                    "address_weight": 0.0  # 기본 가중치 값
+                    "title_weight": 1.0, 
+                    "address_weight": 0.0
                 }
                 }
             }


### PR DESCRIPTION
# Modify response field from 'script' to 'query' for ES query template 
## Related Issue
#4 

## Changes Made
1. Update Query Response Models
> Modify the response of the query API so that all values under the “script” key are returned as strings.

```json
{
  "script": "{\"query\": \"{\\n            \\\"_source\\\": [\\\"title\\\", \\\"address\\\", \\\"location\\\"],\\n            \\\"query\\\": {\\n            \\\"script_score\\\": {\\n                \\\"query\\\": {\\n                \\\"match_all\\\": {}\\n                },\\n                \\\"script\\\": {\\n                \\\"source\\\": \\\"\\\"\\\"\\n                    double titleWeight = params.title_weight;\\n                    double addressWeight = params.address_weight;\\n                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + \\n                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');\\n                \\\"\\\"\\\",\\n                \\\"params\\\": {\\n                    \\\"query_vector\\\": query_embedding,\\n                    \\\"title_weight\\\": 0.0,\\n                    \\\"address_weight\\\": 1.0\\n                }\\n                }\\n            }\\n            }\\n        }\"}"
}
```

# New Endpoints
---

## Implementation Details


## Testing

```shell
# Test query generation endpoint
curl -X POST "http://localhost:8000/query" \
-H "Content-Type: application/json" \
-d '{"text":"강남역 스타벅스"}'
```
