### PR TITLE
[fix] query api 에서 intent 구별, query template 반환되도록 수정

### DIFF
--- a/fastapi/intent-recognition-api/app/models/intent.py
+++ b/fastapi/intent-recognition-api/app/models/intent.py
@@ -21,4 +21,4 @@ class SearchQueryRequest(BaseModel):
     text: str
 
 class SearchQueryResponse(BaseModel):
-    script: str
+    script: Dict[str, Any]

--- a/fastapi/intent-recognition-api/app/routers/router.py
+++ b/fastapi/intent-recognition-api/app/routers/router.py
@@ -8,15 +8,17 @@ router = APIRouter()
 
 @router.post("/recognize-intent", response_model=IntentResponse)
 async def recognize_intent(request: IntentRequest):
-    return classify_intent(request.text)
-
+    intent = classify_intent(request.text)
+    return intent
 
 @router.post("/vectorized-text", response_model=SearchResponse)
-async def vectorized_text(request: SearchRequest):
-    return vectorized_text(request.text)
+async def vectorize(request: SearchRequest):
+    embeded = vectorized_text(request.text)
+    return embeded
 
 @router.post("/query", response_model=SearchQueryResponse)
 async def get_query(request: SearchQueryRequest):
     intent = classify_intent(request.text)
+    print(intent)
     query = generate_query_by_intent(intent['intent'])
-    return SearchQueryResponse(script=json.dumps(query))
+    return {'script' : query}

--- a/fastapi/intent-recognition-api/app/services/intent_classifier.py
+++ b/fastapi/intent-recognition-api/app/services/intent_classifier.py
@@ -1,3 +1,4 @@
+import json
 from transformers import pipeline
 from typing import Dict, List
 from app.services.model import model
@@ -39,5 +40,4 @@ def classify_intent(input_data: str) -> Dict[str, List[str]]:
 
 def generate_query_by_intent(intent: str) -> Dict[str, str]:
     query = intent_classifier.generate_query_by_intent(intent)
-    print('query:', query)
-    return {'query' : query}
+    return query

--- a/fastapi/intent-recognition-api/app/services/query/address_name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_name_query.py
@@ -4,30 +4,30 @@ from typing import Dict, List
 class AddressNameQuery:
     def __init__(self):
         pass
-    def generate_query(self, query_embedding : List[float]) -> str:
-        return '''{
+    def generate_query(self, query_embedding : List[float]) -> Dict[str, str]:
+        return {
             "_source": ["title", "address", "location"],
             "query": {
             "script_score": {
                 "query": {
-                "match_all": {}
+                    "match_all": {}
                 },
                 "script": {
-                "source": """
-                    double titleWeight = params.title_weight;
-                    double addressWeight = params.address_weight;
-                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + 
-                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
-                """,
+                    "source": "\
+                        double titleWeight = params.title_weight;\
+                        double addressWeight = params.address_weight;\
+                        return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + \
+                        addressWeight * cosineSimilarity(params.query_vector, 'address_vector');\
+                    ",
                 "params": {
-                    "query_vector": query_embedding,
+                    "query_vector": [],
                     "title_weight": 1.0, 
                     "address_weight": 1.0
                 }
                 }
             }
             }
-        }'''
+        }
 
 
 address_name_query = AddressNameQuery()

--- a/fastapi/intent-recognition-api/app/services/query/address_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/address_query.py
@@ -4,30 +4,28 @@ from app.services.query.query_interface import QueryInterface
 class AddressQuery(QueryInterface):
     def __init__(self):
         pass
-    def generate_query(self, query_embedding : List[float]) -> str:
-        return '''{
-            "_source": ["title", "address", "location"],
+    def generate_query(self, query_embedding : List[float]) -> Dict[str, str]:
+        return {
+        "_source": ["title", "address", "location"],
+        "query": {
+        "script_score": {
             "query": {
-            "script_score": {
-                "query": {
-                "match_all": {}
-                },
-                "script": {
-                "source": """
-                    double titleWeight = params.title_weight;
-                    double addressWeight = params.address_weight;
-                    return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') + 
-                       addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
-                """,
-                "params": {
-                    "query_vector": query_embedding,
-                    "title_weight": 0.0,
-                    "address_weight": 1.0
-                }
-                }
+            "match_all": {}
+            },
+            "script": {
+            "source": "double titleWeight = params.title_weight;\
+                  double addressWeight = params.address_weight;\
+                  return titleWeight * cosineSimilarity(params.query_vector, 'title_vector') +\
+                  addressWeight * cosineSimilarity(params.query_vector, 'address_vector');",
+            "params": {
+                "query_vector": [],
+                "title_weight": 0.0,
+                "address_weight": 1.0
             }
             }
-        }'''
+        }
+        }
+    }
 
 
 address_query = AddressQuery()

--- a/fastapi/intent-recognition-api/app/services/query/name_query.py
+++ b/fastapi/intent-recognition-api/app/services/query/name_query.py
@@ -5,8 +5,8 @@ from app.services.query.query_interface import QueryInterface  # Absolute import
 class NameQuery(QueryInterface):
     def __init__(self):
         pass
-    def generate_query(self, query_embedding : List[float]) -> str:
-        return '''{
+    def generate_query(self, query_embedding : List[float]) -> Dict[str, str]:
+        return {
             "_source": ["title", "address", "location"],
             "query": {
             "script_score": {
@@ -21,11 +21,11 @@ class NameQuery(QueryInterface):
                        addressWeight * cosineSimilarity(params.query_vector, 'address_vector');
                 """,
                 "params": {
-                    "query_vector": query_embedding,
+                    "query_vector": [],
                     "title_weight": 1.0, 
                     "address_weight": 0.0
                 }
                 }
             }
             }
-        }'''
+        }

--- a/fastapi/intent-recognition-api/app/services/query/query_interface.py
+++ b/fastapi/intent-recognition-api/app/services/query/query_interface.py
@@ -3,6 +3,6 @@ from abc import ABC, abstractmethod
 
 class QueryInterface(ABC):
     @abstractmethod
-    def generate_query(self, query_embedding: List[float]) -> str:
+    def generate_query(self, query_embedding: List[float]) -> Dict[str, str]:
         pass
     

--- a/fastapi/intent-recognition-api/app/services/query_vectorizer.py
+++ b/fastapi/intent-recognition-api/app/services/query_vectorizer.py
@@ -13,12 +13,10 @@ class QueryVectorizer:
             raise HTTPException(status_code=400, detail="Query is empty.")
 
         # query를 벡터로 변환
-        embeddings = self.classifier(text)
-        vector = np.mean(embeddings[0], axis = 0).tolist()
-        print(len(vector))
+        embeddings = self.classifier.encode(text, normalize = True)
         # 결과 반환 (JSON)
         return {
-            "vector": vector
+            "vector": embeddings.tolist()
         }
 
 query_vectorizer = QueryVectorizer()

--- a/recommendation/infrastructure/ModelServerCaller.go
+++ b/recommendation/infrastructure/ModelServerCaller.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	embedQueryUrl             = "http://127.0.0.1:8000/embed/query"
+	embedQueryUrl             = "http://127.0.0.1:8000/vectorized-text"
+	getQueryByIntentUrl       = "http://127.0.0.1:8000/query"
 	ModelServerCallerInit     sync.Once
 	modelServerCallerInstance *modelServiceCaller
 )
@@ -17,6 +18,7 @@ var (
 type (
 	ModelServiceCaller interface {
 		CallEmbedQuery(query *RequestEmbedQuery) ResponseEmbedQuery
+		CallQueryByIntent(query *RequestScriptQuery) ResponseScriptQuery
 	}
 
 	modelServiceCaller struct {
@@ -44,6 +46,26 @@ func (m modelServiceCaller) CallEmbedQuery(request *RequestEmbedQuery) ResponseE
 	}
 	var responseDTO ResponseEmbedQuery
 	parsingDto(&responseDTO, body)
+	return responseDTO
+}
+
+func (m modelServiceCaller) CallQueryByIntent(query *RequestScriptQuery) ResponseScriptQuery {
+	req := jsonMarshall(query)
+	res, err := http.Post(getQueryByIntentUrl, "application/json", bytes.NewBuffer(req))
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	var responseDTO ResponseScriptQuery
+	err = json.Unmarshal(body, &responseDTO)
+	if err != nil {
+		panic(err)
+	}
 	return responseDTO
 }
 

--- a/recommendation/infrastructure/dto.go
+++ b/recommendation/infrastructure/dto.go
@@ -5,5 +5,38 @@ type ResponseEmbedQuery struct {
 }
 
 type RequestEmbedQuery struct {
-	Query string `json:"query"`
+	Text string `json:"text"`
+}
+
+type RequestScriptQuery struct {
+	Text string `json:"text"`
+}
+
+type ResponseScriptQuery struct {
+	Script ScriptBody `json:"script"`
+}
+
+type ScriptBody struct {
+	Source []string  `json:"_source"`
+	Query  QueryBody `json:"query"`
+}
+
+type QueryBody struct {
+	ScriptScore ScriptScore `json:"script_score"`
+}
+
+type ScriptScore struct {
+	Query  interface{} `json:"query"`
+	Script Script      `json:"script"`
+}
+
+type Script struct {
+	Source string       `json:"source"`
+	Params ScriptParams `json:"params"`
+}
+
+type ScriptParams struct {
+	QueryVector   []float64 `json:"query_vector"`
+	TitleWeight   float64   `json:"title_weight"`
+	AddressWeight float64   `json:"address_weight"`
 }

--- a/recommendation/service/searchService.go
+++ b/recommendation/service/searchService.go
@@ -43,12 +43,20 @@ func NewSearchService(repository repository.PoiRepository, embeddingServer infra
  */
 func (s *searchService) SearchTitle(c context.Context, title string) []dto.PoiEntity {
 	embedResponse := s.getVector(c, title)
-	return s.repository.SearchPoiByTitle(c, embedResponse.Vector, "vector_poi")
+	scriptQuery := s.getQueryByIntent(title)
+	return s.repository.SearchPoiByTitle(c, embedResponse.Vector, scriptQuery, "vector_poi")
 }
 
 func (s *searchService) getVector(c context.Context, title string) infrastructure.ResponseEmbedQuery {
 	return s.embeddingServer.CallEmbedQuery(
 		&infrastructure.RequestEmbedQuery{
-			Query: title,
+			Text: title,
+		})
+}
+
+func (s *searchService) getQueryByIntent(query string) infrastructure.ResponseScriptQuery {
+	return s.embeddingServer.CallQueryByIntent(
+		&infrastructure.RequestScriptQuery{
+			Text: query,
 		})
 }


### PR DESCRIPTION
# query api 에서 intent 구별, query template 반환되도록 수정
## Related Issue
#4 

## Changes Made
1. Update Query API
> Create single endpoint for intent and query generation

# New Endpoints
---

## Implementation Details
1. Update `/query` router endpoint
2. Add combined service logic
3. Return unified response
4. Modify `/api/v1/poi` router endpoint

## Testing

```shell
# Test query generation endpoint
curl -X POST "http://localhost:8000/query" \
-H "Content-Type: application/json" \
-d '{"text":"강남역 스타벅스"}'
```
