### PR TITLE
Feat: #8-job2 Add search history tracking 

### DIFF
--- a/recommendation/api/v1/poi.go
+++ b/recommendation/api/v1/poi.go
@@ -40,9 +40,9 @@ func (p poiController) SearchPoi(ctx *gin.Context) {
 		return
 	}
 	req := ctx.Request.Context()
-	logger.WithTrace(ctx).Info("request In : ", parsingJsonMarshal(searchRequest))
+	logger.WithTrace(ctx).Info(parsingJsonMarshal(searchRequest))
 	response := p.searchService.SearchTitle(req, searchRequest.Title)
-	if len(response) == 0 {
+	if len(response) != 0 {
 		res := domain.BuildResponseSuccess("success", response)
 		ctx.JSON(http.StatusOK, res)
 		return

--- a/recommendation/logger/logger.go
+++ b/recommendation/logger/logger.go
@@ -45,6 +45,9 @@ func WithTrace(ctx *gin.Context) *log.Entry {
 	if spanID := ctx.Request.Header.Get("X-Span-ID"); spanID != "" {
 		fields["span_id"] = spanID
 	}
+	if userId := ctx.Request.Header.Get("X-User-ID"); userId != "" {
+		fields["user_id"] = userId
+	}
 
 	return log.WithFields(fields)
 }
@@ -99,7 +102,7 @@ func RequestLoggerMiddleware() gin.HandlerFunc {
 			"latency":     time.Since(start).String(),
 			"queryParams": c.Request.URL.Query(),
 			"headers":     c.Request.Header,
-			"body":        string(requestBodyBytes),
+			"body":        requestBodyBytes,
 		}).Info("API Request")
 	}
 }

--- a/recommendation/logger/loggerHooker.go
+++ b/recommendation/logger/loggerHooker.go
@@ -46,6 +46,16 @@ func (h ElasticsearchHooker) Fire(entry *logrus.Entry) error {
 		"message":    entry.Message,
 		"fields":     entry.Data,
 	}
+
+	// entry.Message가 JSON 포맷인지 확인하고 title 필드 추출
+	var messageMap map[string]interface{}
+	if err := json.Unmarshal([]byte(entry.Message), &messageMap); err == nil {
+		if title, ok := messageMap["title"]; ok {
+			doc["keyword"] = title
+			print(title)
+		}
+	}
+
 	docBytes, err := json.Marshal(doc)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Add search history tracking 
## Related Issue
#8 

## Changes Made
1. If client use `/v1/api/poi` api, send request log to elasticsearch log index
2. extract title value


# New Endpoints
---

## Implementation Details
1. Modify logger hook. parse context request body to interface map

## Testing
- 
